### PR TITLE
Handle interrupts in concurrency examples

### DIFF
--- a/src/com/company/Consumer.java
+++ b/src/com/company/Consumer.java
@@ -17,7 +17,10 @@ public class Consumer implements Runnable {
             System.out.format("MESSAGE RECEIVED: %s%n", message);
             try {
                 Thread.sleep(random.nextInt(5000));
-            } catch (InterruptedException e) {}
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
         }
     }
 }

--- a/src/com/company/Drop.java
+++ b/src/com/company/Drop.java
@@ -16,7 +16,9 @@ public class Drop {
         while (empty) {
             try {
                 wait();
-            } catch (InterruptedException e) {}
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
         // Toggle status.
         empty = true;
@@ -32,7 +34,9 @@ public class Drop {
         while (!empty) {
             try {
                 wait();
-            } catch (InterruptedException e) {}
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
         // Toggle status.
         empty = false;

--- a/src/com/company/Producer.java
+++ b/src/com/company/Producer.java
@@ -23,6 +23,8 @@ public class Producer implements Runnable {
             try {
                 Thread.sleep(random.nextInt(5000));
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
             }
         }
         drop.put("DONE");

--- a/src/com/company/SimpleThreads.java
+++ b/src/com/company/SimpleThreads.java
@@ -30,6 +30,7 @@ public class SimpleThreads {
                 }
             } catch (InterruptedException e) {
                 threadMessage("I wasn't done!");
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
## Summary
- Preserve thread interrupt status in Drop, Producer, Consumer, and SimpleThreads to avoid lost interrupts.
- Break out of loops when interrupted to allow graceful shutdown.

## Testing
- `javac -cp src -d out src/com/company/Drop.java src/com/company/Producer.java src/com/company/Consumer.java src/com/company/SimpleThreads.java`


------
https://chatgpt.com/codex/tasks/task_e_6898d331c2dc8331b7cbfc0e286f57fc